### PR TITLE
Commit

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,3 +20,4 @@ Contents
 
    usage
    api
+   


### PR DESCRIPTION
Lumache has its documentation hosted on Read the Docs.