### PR TITLE
Use a YAML file and Python requirements

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,10 @@
+version: "2"
+
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.10"
+
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx==7.1.2
+sphinx-rtd-theme==1.3.0rc1


### PR DESCRIPTION
The `.readthedocs.yaml` file is now required.

Besdies, we are not installing the Read the Docs Sphinx theme by default. Due to that, we need to manually install it via `requirements.txt`