### PR TITLE
Use a explicit `sphinx.configuration`

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,3 +8,6 @@ build:
 python:
   install:
     - requirements: docs/requirements.txt
+
+sphinx:
+  configuration: docs/source/conf.py


### PR DESCRIPTION
Making this config explicit instead of realying on Read the Docs finding the correct `conf.py` file.